### PR TITLE
Add license and unit test

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -24,3 +24,10 @@ python vesting_analyzer.py
 ```
 În Colab, încărcați fișierele proiectului și rulați aceleași comenzi în celule.
 
+
+## Testare
+
+Pentru a rula testele unitare se foloseste `pytest`. Unele module externe pot incarca automat pluginuri care nu sunt necesare, asa ca recomandam dezactivarea autoload-ului:
+```bash
+PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ gradio==4.22.0
 plotly==5.18.0
 pandas==2.2.1
 
+pytest==7.4.4

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,2 @@
+import os
+os.environ.setdefault('PYTEST_DISABLE_PLUGIN_AUTOLOAD', '1')

--- a/tests/test_vesting_logic.py
+++ b/tests/test_vesting_logic.py
@@ -1,0 +1,28 @@
+import pandas as pd
+import vesting_logic
+
+class DummyAnalyzer:
+    def __init__(self, network):
+        self.network = network
+    def analyze_contracts(self, addresses, names):
+        return [{
+            "Contract": "Test",
+            "Address": addresses[0],
+            "Vested": 100,
+            "Released": 10,
+            "Security Score": 80
+        }]
+    def generate_security_chart(self, results):
+        return "security_chart"
+    def generate_token_chart(self, results):
+        return "token_chart"
+
+def test_analyze_vesting_contracts(monkeypatch):
+    monkeypatch.setattr(vesting_logic, "VestingAnalyzer", DummyAnalyzer)
+    df, security_plot, token_plot = vesting_logic.analyze_vesting_contracts(
+        "0xabc", "Test", "mainnet"
+    )
+    assert isinstance(df, pd.DataFrame)
+    assert df.iloc[0]["Contract"] == "Test"
+    assert security_plot == "security_chart"
+    assert token_plot == "token_chart"


### PR DESCRIPTION
## Summary
- add MIT License
- write unit tests for `vesting_logic.analyze_vesting_contracts`
- describe how to run tests in README
- add pytest to requirements

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68551835bfa88320b06ad60dc0b1fdd0