### PR TITLE
Fix pip conflicts for Google Colab

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ Rulați următoarea comandă pentru a instala pachetele necesare:
 pip install -r requirements.txt
 ```
 
+**Notă pentru Google Colab:** mediul Colab include deja anumite pachete cu
+versiuni blocate, în special `pandas` și `requests`. Pentru a evita mesaje de
+conflict la instalare este recomandat să păstrați versiunile existente în Colab
+prin rularea comenzii de mai sus fără opțiunea `--upgrade`.
+
 ## Rulare
 
 Aplicația poate fi utilizată local sau în Google Colab. Pentru rularea locală executați:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 web3>=6.10
-requests>=2.32.4
+requests==2.32.3
 python-dotenv>=1.1.0
 gradio>=5.34.2
 plotly>=6.1.2
-pandas>=2.3.0
+pandas==2.2.2
 
 pytest==7.4.4


### PR DESCRIPTION
## Summary
- pin `requests` and `pandas` versions to match Google Colab defaults
- document Colab note about keeping preinstalled versions

## Testing
- `pip install -q -r requirements.txt`
- `PYTHONPATH=. PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68551a2632dc83209044394e076aba9c