### PR TITLE
Enable public Gradio link

### DIFF
--- a/vesting_analyzer.py
+++ b/vesting_analyzer.py
@@ -49,4 +49,4 @@ def create_interface():
 
 if __name__ == "__main__":
     interface = create_interface()
-    interface.launch(server_name="0.0.0.0", server_port=7860)
+    interface.launch(server_name="0.0.0.0", server_port=7860, share=True)


### PR DESCRIPTION
## Summary
- allow launching the Gradio interface with `share=True` to expose a public link

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68551c0705e08320a7c09fcd3874a67b